### PR TITLE
fix: change cookie settings from local to remote URL for (users)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -10,8 +10,8 @@ const cookieParser = require("cookie-parser");
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 const corsOptions = {
-  origin: ["http://10.104.217.162:8080","http://localhost:3000", "http://192.168.56.1:3000","https://coursifyapp.vercel.app"],
-  credentials:true,
+  origin: ["https://coursifyapp.vercel.app","http://10.104.217.162:8080","http://localhost:3001","http://localhost:8080", "http://192.168.56.1:3000","http://localhost:3000"],
+  credentials: true,
   allowedHeaders: ['Content-Type', 'Authorization'],
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']
 }

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -107,8 +107,9 @@ userRouter.post("/signin", async (req, res) => {
     res.cookie("token", token, {
       httpOnly: true,
       maxAge: 900000,
-      sameSite: "Lax",
-      secure: false  // use true only on HTTPS
+      sameSite: "Strict",
+      secure: true,  // use true only on HTTPS
+      path:"/"
     });
     res.status(200).
       json({
@@ -131,8 +132,9 @@ userRouter.post("/signin", async (req, res) => {
 //signout:
 userRouter.post("/signout", (req,res)=>{
   try{
-    // const token = req.headers["authorization"].substring(7);
-    const token = req.cookies["token"];
+    //clear the cookie:
+    //invalidate the token:
+    const token = req.cookies['token'];
     console.log(token);
     res.status(200).clearCookie("token").json({success: true, data:{code: "LOGOUT_SUCCESSFUL", message:"Logged Out Successfully"}});
   }catch(error){


### PR DESCRIPTION
In user.js:
- Cookie settings changed. `samesite:Lax` attribute is now `samesite:Strict`.
- It now restricts the cookies from being sent in headers when making a cross-site request.